### PR TITLE
fix: Use https CAPI endpoint

### DIFF
--- a/src/js/fetcher.js
+++ b/src/js/fetcher.js
@@ -21,7 +21,7 @@ export function transformContent(content) {
 }
 
 async function capi(params) {
-    var capi_uri = 'http://content.guardianapis.com/search?' + querystring.stringify(params);
+    var capi_uri = 'https://content.guardianapis.com/search?' + querystring.stringify(params);
     gu.log.debug(`Requesting ${capi_uri}`)
     var body = await rp({
         uri: capi_uri,


### PR DESCRIPTION
## What does this change?
CAPI is available over https, so we should use it.

This'll also allow us to change the egress rules, removing TCP/80.
